### PR TITLE
refactor: remove StructInfo name

### DIFF
--- a/include/mun_abi.h
+++ b/include/mun_abi.h
@@ -137,8 +137,6 @@ typedef struct
  */
 typedef struct
 {
-    /// Struct name
-    const char *name;
     /// Struct fields' names
     const char *const *field_names;
     /// Struct fields' information


### PR DESCRIPTION
This prevents duplicate storage as the struct's name is already stored
in the `TypeInfo`.