### PR TITLE
misc: renamed GC to Gc

### DIFF
--- a/include/mun_abi.h
+++ b/include/mun_abi.h
@@ -22,7 +22,7 @@ enum MunStructMemoryKind
      * A garbage collected struct is allocated on the heap and uses reference semantics when passed
      * around.
      */
-    GC,
+    Gc,
     /**
      * A value struct is allocated on the stack and uses value semantics when passed around.
      *


### PR DESCRIPTION
When bumping Rust to 1.51 I had to rename the enum value `GC` to `Gc` in accordance with the Rust style guide. This also changes the ABI.